### PR TITLE
Update Discord invite link in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@ We're open to ideas and people willing to contribute.</p>
 If you think you can help us, contact us on Discord (see below) and ask for Smx or lprot.</p>
 
 <p>You can also join this chatroom:</p>
-<a href="https://discord.gg/nKQW6FPWeM"><img src="https://img.shields.io/badge/discord-chat-blue" /></a>
+<a href="https://discord.gg/xWqRVEm"><img src="https://img.shields.io/badge/discord-chat-blue" /></a>
 
 <h3>
 <a id="authors-and-contributors" class="anchor" href="#authors-and-contributors" aria-hidden="true"><span class="octicon octicon-link"></span></a>Authors and Contributors</h3>


### PR DESCRIPTION
This invite directs users to #welcome rather than a nonexistent channel.